### PR TITLE
Fix encoding

### DIFF
--- a/{{ cookiecutter.repo_name }}/.hooks/strip_notebooks.py
+++ b/{{ cookiecutter.repo_name }}/.hooks/strip_notebooks.py
@@ -27,7 +27,7 @@ def process(git: Path, ipynb_path: Path, stripped_path: Path, no_index: bool):
     with ipynb_path.open(encoding='utf-8') as f_in:
         data = json.load(f_in)
     stripped_path.parent.mkdir(parents=True, exist_ok=True)
-    with stripped_path.open('w') as f_out:
+    with stripped_path.open('w', encoding='utf-8') as f_out:
         for cell in data['cells']:
             cell_type = cell['cell_type']
             source = cell['source']


### PR DESCRIPTION
Running `strip_notebooks` hook on a notebook with e.g. single code cell `# test ąęćś` resulted in the following error.
```
Traceback (most recent call last):
  File "D:\Programowanie\PROJEKTY\FORKES\repository-template\{{ cookiecutter.repo_name }}\.hooks\strip_notebooks.py", line 84, in <module>
    main(**vars(parser.parse_args()))
  File "D:\Programowanie\PROJEKTY\FORKES\repository-template\{{ cookiecutter.repo_name }}\.hooks\strip_notebooks.py", line 75, in main
    process(git=git, ipynb_path=path, stripped_path=stripped_path, no_index=no_index)
  File "D:\Programowanie\PROJEKTY\FORKES\repository-template\{{ cookiecutter.repo_name }}\.hooks\strip_notebooks.py", line 41, in process
    print(line.rstrip('\n'), file=f_out)
  File "C:\Program Files\Python310\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 7-10: character maps to <undefined>
```
Setting the encoding to utf-8, as in the input file, solves the problem.